### PR TITLE
Improve rhythm sound quality

### DIFF
--- a/software/midism/docs/MIDI_class.pu
+++ b/software/midism/docs/MIDI_class.pu
@@ -18,7 +18,7 @@ Voice "0..*" -o "0..1" NoteChannel : holdQueue <
 Voice "0..*" -o "0..1" NoteChannel : freeQueue <
 VoiceAllocator "0..1" o- "0..*" MidiChannelObserver : observers >
 VoiceAllocator "0..1" o-- "0..*" Voice : voice_pool >
-OpnBase "0..1" -- "0..1" RhythmChannel : module >
+OpnBase "0..*" -- "0..1" RhythmChannel : modules <
 NoteVoice "0..1" -- "1" OpnBase : module >
 CsmVoice "0..1" -- "1..*" OpnBase : modules >
 MidiChannel "0..*" <-o "0..1" MidiProcessor : channels <
@@ -130,7 +130,7 @@ class NoteChannel {
   +void PitchBend(val)
 }
 class RhythmChannel {
-  -OpnBase* module
+  -std::array<OpnBase*, 4>& modules
   -uint8_t percussion_map[54]
   +void Reset()
   +void SetVolume(vol)

--- a/software/midism/docs/README.md
+++ b/software/midism/docs/README.md
@@ -23,19 +23,31 @@ MIDIチャンネルのインターフェースである。
 #### NoteChannel
 
 MIDIチャンネル1-9,11-16用を管理する実装クラス。MidiChannelを継承する。
+MidiProcessorから、MidiChannelのインターフェースで呼び出される。
 
 Voice管理用のキューを持ち、NoteVoiceとCsmVoiceの制御を行う。
 
 #### RhythmChannel
 
 MIDIチャンネル10で使用するリズム用チャンネルの実装クラス。MidiChannelを継承する。
+MidiProcessorから、MidiChannelのインターフェースで呼び出される。
 
-MidiProcessorからは、MidiChannelのインターフェースで呼び出される。パーカッションマップを持っており、指定されたProgramはこのマップから選択する。
+パーカッションマップを持っており、ノートに対応する音源はこのマップから選択する。非対応のノート番号が指定された場合は発音しない。
+YM2608のリズム音源のみを使用しているので、音源が6種類しかなく、パーカッションマップのすべてには対応できていない。
+SSG音源を使用した音源の実装も考えられるが未対応。
 
-- 現在の実装
-  - YM2608のリズム音源を使用しているが、6種類しかないので、パーカッションマップにすべて対応させることができていない。非対応のProgramを指定された場合は発音しない。
-  - NoteOn/OffはMidiChannelのインターフェース経由で呼ばれ、YM2608のリズム音源で発音する。
-  - FM音源Voiceを使用しないので、Voiceインスタンスはこのチャンネルには割り当てていない。
+同時発音数を稼ぐため、コンストラクタで渡されるFM音源モジュールのリストに含まれる全てのOPNAを利用する。OPNAがひとつも存在しない場合は発音しない。
+FM音源のVoiceを使用しないので、このチャンネルにVoiceインスタンスは割り当てない。
+
+リズムチャンネルでは、NoteOffまたはvelocity=0でのNoteOnでの消音処理を行わないが、以下の排他グループ内の連続発音時は、強制消音後に指定ノートの発音を行う。([General MIDI Lite3.1.7.1](https://amei.or.jp/midistandardcommittee/Recommended_Practice/General_MIDI_Lite_v1.0_japanese.pdf)参照)
+
+|排他グループ|ノート番号  |
+|----------|----------|
+|クローズド/ペダル/オープン ハイハット|42, 44, 46|
+|ショート/ロング ホイッスル|71, 72    |
+|ショート/ロング ギロ|73, 74    |
+|ミュート/オープン クイーカ|78, 79    |
+|ミュート/オープン トライアングル|80, 81    |
 
 ### クラス図
 
@@ -138,8 +150,7 @@ OPNでは4つのオペレータにキャリアとモジュレータという役�
 
 ### Rhythm音源
 
-MIDIチャンネル10ではRhythmChannelクラスで実装されており、YM2608(OPNA)の内蔵する6種類のRhythm音源を使用している。
-RTL(Rhythm Total Level)とIL(Instrument Total Level)の2種類の音量体系を持つ。
+YM2608のRhythm音源は、RTL(Rhythm Total Level)とIL(Instrument Total Level)の2種類の音量体系を持つ。
 RTLはリズム全体の音量で、63で0dB(最大音量)、0で-47.5dB(ミュート)となる。
 ITLは六種それぞれの楽器ごとの音量で、31で0dB(最大音量)、0で-23.25dB(ミュート)である。
 
@@ -255,4 +266,5 @@ OPNAボードを使用する場合は、config.hの以下のマクロを有効�
 
 ## その他
 
+- [General MIDI Lite 仕様書](https://amei.or.jp/midistandardcommittee/Recommended_Practice/General_MIDI_Lite_v1.0_japanese.pdf)
 - [FM音源LSIのTips](./tips.md)

--- a/software/midism/main.cpp
+++ b/software/midism/main.cpp
@@ -52,10 +52,9 @@ int main(int argc, char** argv) {
         &module_3   // Dock3
     };
 
-    // MIDIチャンネルのインスタンス生成とリズムチャンネルの設定
-    // (ここではmodule_3のYM2608をリズム用に使用している)
+    // MIDIチャンネルのインスタンス生成
     MidiFactory factory(modules);
-    auto midi_channels = factory.Create(&module_3);
+    auto midi_channels = factory.Create();
 
     // MIDI processorの生成
     MidiProcessor mp(midi_channels);

--- a/software/midism/midi/MidiFactory.cpp
+++ b/software/midism/midi/MidiFactory.cpp
@@ -25,7 +25,7 @@ MidiFactory::~MidiFactory() {
     }
 }
 
-std::array<MidiChannel*, MIDI_CHANNELS>& MidiFactory::Create(OpnBase* rhythm_module) {
+std::array<MidiChannel*, MIDI_CHANNELS>& MidiFactory::Create() {
     VoiceAllocator& allocator = VoiceAllocator::GetInstance();
 
     // VoiceAllocatorにFM音源モジュールのチャンネルを登録
@@ -57,7 +57,7 @@ std::array<MidiChannel*, MIDI_CHANNELS>& MidiFactory::Create(OpnBase* rhythm_mod
     for (int i = 0; i < channels.size(); i++) {
         if (i == RhythmChannel::MIDI_RHYTHM_CHANNEL) {
             // リズムチャンネル
-            RhythmChannel* rc = new RhythmChannel(rhythm_module);
+            RhythmChannel* rc = new RhythmChannel(modules);
             channels[i]       = rc;
             // VoiceAllocatorにオブザーバーを登録
             allocator.AddObserver(i, rc);

--- a/software/midism/midi/MidiFactory.h
+++ b/software/midism/midi/MidiFactory.h
@@ -33,8 +33,7 @@ public:
 
     /**
      * @brief MIDIチャンネルとMIDI Voiceの生成
-     * @param rhythm_module 割り当てるリズム音源モジュール
      * @return 生成したMIDIチャンネルの配列
      */
-    std::array<MidiChannel*, MIDI_CHANNELS>& Create(OpnBase* rhythm_module = nullptr);
+    std::array<MidiChannel*, MIDI_CHANNELS>& Create();
 };

--- a/software/midism/midi/channel/RhythmChannel.cpp
+++ b/software/midism/midi/channel/RhythmChannel.cpp
@@ -70,6 +70,24 @@ static constexpr YM2608::RtmInst percussion_map[54] = {
     YM2608::RtmInst::NONE,  // #88(E5)
 };
 
+// 排他ノート管理マップ（ノート範囲42～81）
+static constexpr int exclusive_map[81 - 42 + 1] = {
+    // 排他グループID:
+    //   42/44/46 => 1: ハイハット クローズド/ペダル/オープン
+    //   71/72    => 2: ショート/ロングホイッスル
+    //   73/74    => 3: ショート/ロングギロ
+    //   78/79    => 4: ミュート/オープンクイーカ
+    //   80/81    => 5: ミュート/オープントライアングル
+    //   上記以外  => 0: 排他なし
+    /* 42-46 */ 1, 0, 1, 0, 1,
+    /* 47-70 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /* 71-72 */ 2, 2,
+    /* 73-74 */ 3, 3,
+    /* 75-77 */ 0, 0, 0,
+    /* 78-79 */ 4, 4,
+    /* 80-81 */ 5, 5
+};
+
 //  RTL(Rhythm Total Level)音量テーブル
 //  MIDI volume(x:0-127)を RTL(y:0-63)に変換する。
 //          ｙ = 29.90*log(x+1)
@@ -94,7 +112,16 @@ static constexpr uint8_t ILvolume[128] = {
     30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
 };
 
-RhythmChannel::RhythmChannel(OpnBase* module) : MidiChannel(MIDI_RHYTHM_CHANNEL), module(module) {
+RhythmChannel::RhythmChannel(std::array<OpnBase*, 4>& input_modules)
+    : MidiChannel(MIDI_RHYTHM_CHANNEL) {
+    // 使用可能なYM2608をmodulesに追加
+    // (不本意ながらfm_get_channels()==6でOPNAを判別)
+    for (auto* m : input_modules) {
+        if (m != nullptr && m->fm_get_channels() == 6) {
+            modules.push_back(m);
+        }
+    }
+
     SetOutputLR(LR);        // L/R両チャンネル出力に設定
     init_volume(100, 127);  // デフォルト音量
 }
@@ -111,33 +138,56 @@ void RhythmChannel::Reset() {
 void RhythmChannel::init_volume(uint8_t rtl, uint8_t il) {
     SetVolume(rtl);
     il = ILvolume[il];
-    module->rtm_set_inst_level(YM2608::RtmInst::BD, il);
-    module->rtm_set_inst_level(YM2608::RtmInst::SD, il);
-    module->rtm_set_inst_level(YM2608::RtmInst::TOP, il);
-    module->rtm_set_inst_level(YM2608::RtmInst::HH, il);
-    module->rtm_set_inst_level(YM2608::RtmInst::TOM, il);
-    module->rtm_set_inst_level(YM2608::RtmInst::RIM, il);
+
+    for (auto *m : modules) {
+        if (m) {
+            m->rtm_set_inst_level(YM2608::RtmInst::BD, il);
+            m->rtm_set_inst_level(YM2608::RtmInst::SD, il);
+            m->rtm_set_inst_level(YM2608::RtmInst::TOP, il);
+            m->rtm_set_inst_level(YM2608::RtmInst::HH, il);
+            m->rtm_set_inst_level(YM2608::RtmInst::TOM, il);
+            m->rtm_set_inst_level(YM2608::RtmInst::RIM, il);
+        }
+    }
 }
 
 void RhythmChannel::SetVolume(int vol) {
-    if (volume != vol) {
+    if (!modules.empty() && volume != vol) {
         volume = vol;
-        module->rtm_set_total_level(RTLvolume[vol]);
+        modules[cur_module]->rtm_set_total_level(RTLvolume[vol]);
     }
 }
 
 int RhythmChannel::NoteOn(int key, int velocity) {
+    if (modules.empty()) {
+        return -1;      // 使用可能なYM2608がない
+    }
+
+    // 排他ノートの処理
+    if (key >= 42 && key <= 81) {
+        int group = exclusive_map[key - 42]; // ノート番号に対応する排他グループを取得
+        if (group > 0) { // 排他グループに属している場合
+            int16_t& last_note = last_exclusive_note[group - 1];
+            if (last_note != -1 && last_note != key) {
+                // 直前のノートを強制damp
+                modules[last_module]->rtm_damp_key(percussion_map[last_note - 35]);
+            }
+            last_note = key;  // 現在のノートをlast_exclusive_noteに記憶
+        }
+    }
+
     int st = 1;
     if (key >= 35 && key < sizeof(percussion_map) / sizeof(YM2608::RtmInst) + 35) {
         YM2608::RtmInst note = percussion_map[key - 35];
         if (note != YM2608::RtmInst::NONE) {
             if (velocity == 0) {
-                module->rtm_damp_key(note);
                 st = 0;
             } else {
                 // velocityに応じた音量変化
-                module->rtm_set_inst_level(note, ILvolume[volume]);
-                module->rtm_turnon_key(note);
+                modules[cur_module]->rtm_set_inst_level(note, ILvolume[volume]);
+                modules[cur_module]->rtm_turnon_key(note);
+                last_module = cur_module;
+                cur_module  = (cur_module + 1) % modules.size();
             }
             DPRINTF(1, " *%02d ", key);
             return st;
@@ -148,7 +198,7 @@ int RhythmChannel::NoteOn(int key, int velocity) {
 }
 
 int RhythmChannel::NoteOff(int key) {
-    return NoteOn(key, 0);
+    return 0;
 }
 
 Voice* RhythmChannel::Release(int mid, bool type) {
@@ -162,4 +212,15 @@ void RhythmChannel::ReleaseAll() {
 void RhythmChannel::dump() {
     MidiChannel::dump();
     printf("  TYPE=RTM\n");
+    printf("  OPNA : ");
+    if (modules.empty()) {
+        printf("None");
+    } else {
+        for (auto& m : modules) {
+            if (m) {
+                printf("%d ", m->id);
+            }
+        }
+    }
+    printf("\n");
 }

--- a/software/midism/midi/channel/RhythmChannel.h
+++ b/software/midism/midi/channel/RhythmChannel.h
@@ -8,22 +8,28 @@
 #include "MidiChannel.h"
 #include "MidiChannelObserver.h"
 #include "YM2608.h"
+#include <array>
+#include <vector>
 
 /**
  * @brief Rhythm Channel class (CH=10)
  */
 class RhythmChannel : public MidiChannel, public MidiChannelObserver {
 private:
-    OpnBase* module;
+    std::vector<OpnBase*> modules;          // 使用可能なモジュール(YM2608)
+    uint8_t last_module            = 0;     // 直前に発音したモジュールのindex
+    uint8_t cur_module             = 0;     // 現在のモジュールのindex
+    int16_t last_exclusive_note[6] = {-1, -1, -1,
+                                      -1, -1, -1};  // 各排他グループの直前のノート番号を記憶
 
 public:
     static constexpr int MIDI_RHYTHM_CHANNEL = 9;  // MIDI CH=10
 
     /**
      * @brief コンストラクタ
-     * @param module Rhythmを割り当てるFM音源モジュール
+     * @param modules FM音源モジュールの配列
      */
-    RhythmChannel(OpnBase* module);
+    RhythmChannel(std::array<OpnBase*, 4>& input_modules);
     RhythmChannel() = delete;
 
     /**
@@ -42,13 +48,15 @@ public:
      * @param key MIDI Note No.
      * @param velocity MIDI Velocity
      * @return -1:Fail, 0:NoteOff, 1:NoteOn
+     * @details 排他ノートを除き消音処理は行わない
      */
     int NoteOn(int key, int velocity) override;
 
     /**
      * @brief Note Off
      * @param key MIDI Note No.
-     * @return -1:Fail, 0:NoteOff, 1:Keep NoteOn
+     * @return 0:NoteOff
+     * @details 消音処理は行わない
      */
     int NoteOff(int key) override;
 
@@ -60,7 +68,6 @@ public:
 
     /**
      * @brief 当該チャンネルに割り当てられたVoiceをすべて解放する
-     * @details FM音源のVoiceは使用しないので何もしない
      */
     void ReleaseAll() override;
 


### PR DESCRIPTION
**リズム音の音質改善**
1. リズム音の複数同時発音をサポートする。YM2608が複数ある場合、全て使用するようにする。
2. リズム音源のグループミュートをサポートする。グループミュートの振る舞いについては[General MIDI Lite仕様書](https://amei.or.jp/midistandardcommittee/Recommended_Practice/General_MIDI_Lite_v1.0_japanese.pdf)の3.1.7.1 リズム・チャンネルを参照。
